### PR TITLE
Unwanted mnemonic

### DIFF
--- a/JCalendar/src/com/toedter/calendar/JDateChooser.java
+++ b/JCalendar/src/com/toedter/calendar/JDateChooser.java
@@ -211,7 +211,7 @@ public class JDateChooser extends JPanel implements ActionListener,
 		calendarButton.addActionListener(this);
 
 		// Alt + 'C' selects the calendar.
-		calendarButton.setMnemonic(KeyEvent.VK_C);
+		// calendarButton.setMnemonic(KeyEvent.VK_C);
 
 		add(calendarButton, BorderLayout.EAST);
 		add(this.dateEditor.getUiComponent(), BorderLayout.CENTER);


### PR DESCRIPTION
Removed default "C" mnemonic keyboard binding because it may conflicts with others user defined ones and anyway it should depends by the locale